### PR TITLE
Refactor prompts into their own file

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,9 +157,9 @@ The founders of BlackRock are:
 Larry Fink graduated from UCLA, where he earned a BA in political science in 1974 and an MBA in 1976.
 ```
 
-#### Q3: When were Larry Fink and Susan Wagner born?
+#### Q3: When was Susan Wagner born?
 ```
-Larry Fink was born on November 2, 1952, in Van Nuys, California. Susan Wagner's birth date is not provided in the relevant context, so I cannot provide that information.
+The relevant context does not provide information about Susan Wagner's birth date. Therefore, I cannot answer the question about when Susan Wagner was born.
 ```
 
 > [!NOTE]
@@ -197,17 +197,17 @@ Just like earlier, we'll answer the following questions using Graph RAG.
 #### Q2: Where did Larry Fink graduate from?
 
 ```
-{question: list(set(result))}
+Larry Fink graduated from UCLA.
 ```
 
 > [!NOTE]
 > Unlike vector retrieval-based RAG, the graph only stored the name of the university that Larry Fink
 > graduated from, so the LLM only has this context to answer the question as it did.
 
-#### Q3: When were Larry Fink and Susan Wagner born?
+#### Q3: When was Susan Wagner born?
 
 ```
-Larry Fink was born on May 26, 1961, and Susan Wagner was born on November 2, 1952.
+Susan Wagner was born on May 26, 1961.
 ```
 
 > [!NOTE]
@@ -251,10 +251,10 @@ The founders of BlackRock are:
 Larry Fink graduated from UCLA, where he earned both a BA in political science in 1974 and an MBA in 1976.
 ```
 
-#### Q3: When were Larry Fink and Susan Wagner born?
+#### Q3: When was Susan Wagner born?
 
 ```
-Larry Fink was born on November 2, 1952, and Susan Wagner was born on May 26, 1961.
+Susan Wagner was born on May 26, 1961.
 ```
 
 #### Q4: How did Larry Fink and Rob Kapito meet?

--- a/hybrid_rag.py
+++ b/hybrid_rag.py
@@ -8,6 +8,8 @@ from openai import OpenAI
 from graph_rag import GraphRAG
 from vector_rag import VectorRAG
 
+import prompts
+
 load_dotenv()
 MODEL_NAME = "gpt-4o-mini"
 COHERE_API_KEY = os.environ.get("COHERE_API_KEY")
@@ -23,24 +25,10 @@ class HybridRAG:
 
     @ell.simple(model=MODEL_NAME, temperature=0.3)
     def hybrid_rag(self, question: str, context: str) -> str:
-        """
-        You are an AI assistant using Retrieval-Augmented Generation (RAG).
-        RAG enhances your responses by retrieving relevant information from a knowledge base.
-        You will be provided with a question and relevant context. Use only this context to answer the question.
-        Do not make up an answer. If you don't know the answer, say so clearly.
-        Always strive to provide concise, helpful, and context-aware answers.
-        """
-
-        return f"""
-        Given the following question and relevant context, please provide a comprehensive and accurate response:
-
-        Question: {question}
-
-        Relevant context:
-        {context}
-
-        Response:
-        """
+        return [
+            ell.system(prompts.RAG_SYSTEM_PROMPT),
+            ell.user(prompts.RAG_USER_PROMPT.format(question=question, context=context)),
+        ]
 
     def run(self, question: str) -> str:
         question_embedding = self.vector_rag.embed(question)
@@ -74,7 +62,7 @@ if __name__ == "__main__":
     response = hybrid_rag.run(question)
     print(f"---\nQ2: {question}\n\n{response}")
 
-    question = "When were Larry Fink and Susan Wagner born?"
+    question = "When was Susan Wagner born?"
     response = hybrid_rag.run(question)
     print(f"---\nQ3: {question}\n\n{response}")
 

--- a/prompts.py
+++ b/prompts.py
@@ -1,0 +1,43 @@
+RAG_SYSTEM_PROMPT = """
+You are an AI assistant using Retrieval-Augmented Generation (RAG).
+RAG enhances your responses by retrieving relevant information from a knowledge base.
+You will be provided with a question and relevant context. Use only this context to answer the question.
+Do not make up an answer. If you don't know the answer, say so clearly.
+Always strive to provide concise, helpful, and context-aware answers.
+"""
+
+CYPHER_SYSTEM_PROMPT = """
+You are an expert in translating natural language questions into Cypher statements.
+You will be provided with a question and a graph schema.
+Use only the provided relationship types and properties in the schema to generate a Cypher statement.
+The Cypher statement could retrieve nodes, relationships, or both.
+Do not include any explanations or apologies in your responses.
+Do not respond to any questions that might ask anything else than for you to construct a Cypher statement.
+"""
+
+RAG_USER_PROMPT = """
+Given the following question and relevant context, please provide a comprehensive and accurate response:
+
+Question: {question}
+
+Relevant context:
+{context}
+
+Response:
+"""
+
+CYPHER_USER_PROMPT = """
+Task: Generate Cypher statement to query a graph database.
+Instructions:
+Schema:
+{schema}
+
+The question is:
+{question}
+
+Instructions:
+Generate the Kùzu dialect of Cypher with the following rules in mind:
+1. Do not include triple backticks ``` in your response. Return only Cypher.
+2. Only use the nodes and relationships provided in the schema.
+3. Use only the provided node and relationship types and properties in the schema.
+"""

--- a/vector_rag.py
+++ b/vector_rag.py
@@ -5,6 +5,8 @@ from dotenv import load_dotenv
 from ell import ell
 from openai import OpenAI
 
+import prompts
+
 
 class VectorRAG:
     def __init__(self, db_path: str, table_name: str = "vectors"):
@@ -25,25 +27,11 @@ class VectorRAG:
         return response.data[0].embedding
 
     @ell.simple(model="gpt-4o-mini", temperature=0.3)
-    def retrieve(self, query: str, context: str) -> str:
-        """
-        You are an AI assistant using Retrieval-Augmented Generation (RAG).
-        RAG enhances your responses by retrieving relevant information from a knowledge base.
-        You will be provided with a query and relevant context. Use only this context to answer the question.
-        Do not make up an answer. If you don't know the answer, say so clearly.
-        Always strive to provide concise, helpful, and context-aware answers.
-        """
-
-        return f"""
-        Given the following query and relevant context, please provide a comprehensive and accurate response:
-
-        Query: {query}
-
-        Relevant context:
-        {context}
-
-        Response:
-        """
+    def retrieve(self, question: str, context: str) -> str:
+        return [
+            ell.system(prompts.RAG_SYSTEM_PROMPT),
+            ell.user(prompts.RAG_USER_PROMPT.format(question=question, context=context)),
+        ]
 
     def run(self, question: str) -> str:
         question_embedding = self.embed(question)
@@ -61,7 +49,7 @@ if __name__ == "__main__":
     response = vector_rag.run(question)
     print(f"---\nQ2: {question}\n\n{response}")
 
-    question = "When were Larry Fink and Susan Wagner born?"
+    question = "When was Susan Wagner born?"
     response = vector_rag.run(question)
     print(f"---\nQ3: {question}\n\n{response}")
 


### PR DESCRIPTION
Ell's [usage docs](https://docs.ell.so/core_concepts/ell_simple.html#usage) show how to explicitly define system and user prompts - this makes for cleaner code than using docstrings when the prompts become complex.

Also, there could be an issue with asking for birth dates of multiple persons in one question (the LLM could non-deterministically mix up the order of the results, so it's best to be specific with the question and help the LLM narrow down the context).